### PR TITLE
Fix Hydra window mode interaction with persistent Snacks picker

### DIFF
--- a/.config/nvim/lua/config/hydra.lua
+++ b/.config/nvim/lua/config/hydra.lua
@@ -19,8 +19,12 @@ end
 local function restore_picker_on_exit()
   for _, picker in ipairs(Snacks.picker.get()) do
     if picker:is_focused() then
+      -- Ensure preview window is visible in layout, then focus input.
+      picker:focus("preview", { show = true })
       picker:focus("input")
-      picker:show_preview()
+      vim.schedule(function()
+        picker:show_preview()
+      end)
       return
     end
   end

--- a/.config/nvim/lua/config/hydra.lua
+++ b/.config/nvim/lua/config/hydra.lua
@@ -1,4 +1,30 @@
 local Hydra = require("hydra")
+local Snacks = require("snacks")
+
+-- After wincmd, if we land on a picker input (insert mode), switch to
+-- normal mode so that subsequent Hydra keys are not typed into the search field.
+local function smart_wincmd(dir)
+  return function()
+    vim.cmd("wincmd " .. dir)
+    for _, picker in ipairs(Snacks.picker.get()) do
+      if picker:is_focused() then
+        vim.cmd("stopinsert")
+        return
+      end
+    end
+  end
+end
+
+-- When Hydra exits, restore picker focus and preview if we're in a picker window.
+local function restore_picker_on_exit()
+  for _, picker in ipairs(Snacks.picker.get()) do
+    if picker:is_focused() then
+      picker:focus("input")
+      picker:show_preview()
+      return
+    end
+  end
+end
 
 Hydra({
   name = "Buffer",
@@ -34,13 +60,16 @@ Hydra({
  _v_: vsplit   _s_: split   _h_: left   _j_: down   _k_: up   _l_: right   _w_: close   _o_: only   _q_: quit ]],
   mode = "n",
   body = "<leader>w",
+  config = {
+    on_exit = restore_picker_on_exit,
+  },
   heads = {
     { "v", function() vim.cmd("vsplit") end, { desc = "Vertical split" } },
     { "s", function() vim.cmd("split") end, { desc = "Horizontal split" } },
-    { "h", function() vim.cmd("wincmd h") end, { desc = "Move left" } },
-    { "j", function() vim.cmd("wincmd j") end, { desc = "Move down" } },
-    { "k", function() vim.cmd("wincmd k") end, { desc = "Move up" } },
-    { "l", function() vim.cmd("wincmd l") end, { desc = "Move right" } },
+    { "h", smart_wincmd("h"), { desc = "Move left" } },
+    { "j", smart_wincmd("j"), { desc = "Move down" } },
+    { "k", smart_wincmd("k"), { desc = "Move up" } },
+    { "l", smart_wincmd("l"), { desc = "Move right" } },
     { "w", function() vim.cmd("wincmd q") end, { desc = "Close window" } },
     { "o", function() vim.cmd("only") end, { desc = "Close others" } },
     { "q", nil, { exit = true } },

--- a/.config/nvim/lua/config/hydra.lua
+++ b/.config/nvim/lua/config/hydra.lua
@@ -19,12 +19,8 @@ end
 local function restore_picker_on_exit()
   for _, picker in ipairs(Snacks.picker.get()) do
     if picker:is_focused() then
-      -- Ensure preview window is visible in layout, then focus input.
-      picker:focus("preview", { show = true })
       picker:focus("input")
-      vim.schedule(function()
-        picker:show_preview()
-      end)
+      picker:show_preview()
       return
     end
   end

--- a/.config/nvim/lua/config/hydra.lua
+++ b/.config/nvim/lua/config/hydra.lua
@@ -15,15 +15,24 @@ local function smart_wincmd(dir)
   end
 end
 
--- When Hydra exits, restore picker focus and preview if we're in a picker window.
+-- When Hydra exits, restore picker focus and preview if a picker is open.
+-- Must use vim.schedule because on_exit fires during Hydra's exit flow.
 local function restore_picker_on_exit()
-  for _, picker in ipairs(Snacks.picker.get()) do
-    if picker:is_focused() then
-      picker:focus("input")
+  vim.schedule(function()
+    local pickers = Snacks.picker.get()
+    local picker = pickers[#pickers] -- latest picker (sorted by id ascending)
+    if not picker or picker.closed then return end
+
+    picker:focus("input", { show = true })
+    if picker.layout:is_hidden("preview") then
+      picker:toggle("preview", { enable = true })
+      vim.schedule(function()
+        if not picker.closed then picker:show_preview() end
+      end)
+    else
       picker:show_preview()
-      return
     end
-  end
+  end)
 end
 
 Hydra({


### PR DESCRIPTION
When navigating to a picker window via Hydra, stopinsert prevents Hydra keystrokes from being typed into the picker's search input. When Hydra exits on a picker window, restore picker focus and preview.

https://claude.ai/code/session_014own9A6Urm1uuzEbTwT58K