### PR TITLE
Integrate Ghost local memory with Claude Code (hook, skill, settings, docs)

### DIFF
--- a/.config/claude/ghost/README.md
+++ b/.config/claude/ghost/README.md
@@ -1,0 +1,30 @@
+# Ghost integration notes for Claude Code
+
+This dotfiles repo integrates a minimal subset of
+`Flowers-of-Romance/ghost` with existing Claude Code settings.
+
+## What is integrated
+
+- Environment variables for Ghost memory adapter path and DB path.
+- Stop hook (`hooks/ghost-memory-sync.sh`) to run best-effort `memory.py sync`.
+- A local Claude skill (`skills/ghost-memory/SKILL.md`) for add/search/sync workflows.
+
+## Setup
+
+1. Place Ghost's `memory.py` at:
+   - `$HOME/.local/share/ghost/memory.py`
+2. Ensure the DB path exists or is creatable:
+   - `$HOME/.local/share/ghost/memory.db`
+3. Install required Python dependencies for your Ghost checkout.
+
+You can override defaults with environment variables in Claude settings:
+
+- `GHOST_HOME`
+- `GHOST_MEMORY_SCRIPT`
+- `GHOST_MEMORY_DB`
+
+## Safety
+
+- Hook is best-effort and never blocks Claude completion.
+- Missing Ghost install is treated as no-op.
+- Do not store secrets in memory entries.

--- a/.config/claude/ghost/README.md
+++ b/.config/claude/ghost/README.md
@@ -6,7 +6,7 @@ This dotfiles repo integrates a minimal subset of
 ## What is integrated
 
 - Environment variables for Ghost memory adapter path and DB path.
-- Stop hook (`hooks/ghost-memory-sync.sh`) to run best-effort `memory.py sync`.
+- Stop hook (`hooks/ghost-memory-sync.sh`) to run best-effort auto-capture (`add`) + `memory.py sync`.
 - A local Claude skill (`skills/ghost-memory/SKILL.md`) for add/search/sync workflows.
 
 ## Setup
@@ -22,9 +22,13 @@ You can override defaults with environment variables in Claude settings:
 - `GHOST_HOME`
 - `GHOST_MEMORY_SCRIPT`
 - `GHOST_MEMORY_DB`
+- `GHOST_AUTO_CAPTURE_ON_STOP` (`1` / `0`)
+- `GHOST_AUTO_CAPTURE_MAX_CHARS` (default `400`)
+- `GHOST_AUTO_SOURCE` (default `claude-stop-hook`)
 
 ## Safety
 
 - Hook is best-effort and never blocks Claude completion.
 - Missing Ghost install is treated as no-op.
 - Do not store secrets in memory entries.
+- Auto-capture text is intentionally short and metadata-focused.

--- a/.config/claude/ghost/README.md
+++ b/.config/claude/ghost/README.md
@@ -25,6 +25,7 @@ You can override defaults with environment variables in Claude settings:
 - `GHOST_AUTO_CAPTURE_ON_STOP` (`1` / `0`)
 - `GHOST_AUTO_CAPTURE_MAX_CHARS` (default `400`)
 - `GHOST_AUTO_SOURCE` (default `claude-stop-hook`)
+- `GHOST_AUTO_CAPTURE_REQUIRE_SUMMARY` (`1` / `0`, default `1`)
 
 ## Safety
 
@@ -32,3 +33,4 @@ You can override defaults with environment variables in Claude settings:
 - Missing Ghost install is treated as no-op.
 - Do not store secrets in memory entries.
 - Auto-capture text is intentionally short and metadata-focused.
+- When `GHOST_AUTO_CAPTURE_REQUIRE_SUMMARY=1`, no memory is added if stop-event summary is unavailable.

--- a/.config/claude/hooks/ghost-memory-sync.sh
+++ b/.config/claude/hooks/ghost-memory-sync.sh
@@ -7,9 +7,11 @@ set -u
 GHOST_HOME="${GHOST_HOME:-$HOME/.local/share/ghost}"
 GHOST_MEMORY_SCRIPT="${GHOST_MEMORY_SCRIPT:-$GHOST_HOME/memory.py}"
 GHOST_MEMORY_DB="${GHOST_MEMORY_DB:-$GHOST_HOME/memory.db}"
+GHOST_AUTO_CAPTURE_ON_STOP="${GHOST_AUTO_CAPTURE_ON_STOP:-1}"
+GHOST_AUTO_CAPTURE_MAX_CHARS="${GHOST_AUTO_CAPTURE_MAX_CHARS:-400}"
+GHOST_AUTO_SOURCE="${GHOST_AUTO_SOURCE:-claude-stop-hook}"
 
-# Read stdin from hook event to avoid broken pipes in Claude hooks.
-cat >/dev/null || true
+INPUT=$(cat || true)
 
 if ! command -v python3 >/dev/null 2>&1; then
   exit 0
@@ -17,6 +19,36 @@ fi
 
 if [ ! -f "$GHOST_MEMORY_SCRIPT" ]; then
   exit 0
+fi
+
+if [ "$GHOST_AUTO_CAPTURE_ON_STOP" = "1" ] && command -v jq >/dev/null 2>&1; then
+  SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+  CURRENT_DIR=$(echo "$INPUT" | jq -r '.workspace.current_dir // empty' 2>/dev/null || true)
+  MODEL=$(echo "$INPUT" | jq -r '.model.display_name // empty' 2>/dev/null || true)
+  SUMMARY=$(echo "$INPUT" | jq -r '.summary // .stop_hook_active_session.summary // empty' 2>/dev/null || true)
+
+  if [ -z "$SUMMARY" ]; then
+    SUMMARY="Claude session completed"
+  fi
+
+  if [ -n "$CURRENT_DIR" ]; then
+    SUMMARY="${SUMMARY} @${CURRENT_DIR}"
+  fi
+  if [ -n "$MODEL" ]; then
+    SUMMARY="${SUMMARY} [model:${MODEL}]"
+  fi
+  if [ -n "$SESSION_ID" ]; then
+    SUMMARY="${SUMMARY} [session:${SESSION_ID}]"
+  fi
+
+  SUMMARY_TRIMMED=$(echo "$SUMMARY" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | cut -c1-"$GHOST_AUTO_CAPTURE_MAX_CHARS")
+
+  if [ -n "$SUMMARY_TRIMMED" ]; then
+    python3 "$GHOST_MEMORY_SCRIPT" add \
+      --db "$GHOST_MEMORY_DB" \
+      --source "$GHOST_AUTO_SOURCE" \
+      --text "$SUMMARY_TRIMMED" >/dev/null 2>&1 || true
+  fi
 fi
 
 # Best-effort sync only. Never block Claude session finalization.

--- a/.config/claude/hooks/ghost-memory-sync.sh
+++ b/.config/claude/hooks/ghost-memory-sync.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Ghost memory sync hook for Claude Code Stop event.
+# Runs only when ghost memory adapter exists.
+
+set -u
+
+GHOST_HOME="${GHOST_HOME:-$HOME/.local/share/ghost}"
+GHOST_MEMORY_SCRIPT="${GHOST_MEMORY_SCRIPT:-$GHOST_HOME/memory.py}"
+GHOST_MEMORY_DB="${GHOST_MEMORY_DB:-$GHOST_HOME/memory.db}"
+
+# Read stdin from hook event to avoid broken pipes in Claude hooks.
+cat >/dev/null || true
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+if [ ! -f "$GHOST_MEMORY_SCRIPT" ]; then
+  exit 0
+fi
+
+# Best-effort sync only. Never block Claude session finalization.
+python3 "$GHOST_MEMORY_SCRIPT" sync --db "$GHOST_MEMORY_DB" >/dev/null 2>&1 || true
+
+exit 0

--- a/.config/claude/hooks/ghost-memory-sync.sh
+++ b/.config/claude/hooks/ghost-memory-sync.sh
@@ -10,6 +10,7 @@ GHOST_MEMORY_DB="${GHOST_MEMORY_DB:-$GHOST_HOME/memory.db}"
 GHOST_AUTO_CAPTURE_ON_STOP="${GHOST_AUTO_CAPTURE_ON_STOP:-1}"
 GHOST_AUTO_CAPTURE_MAX_CHARS="${GHOST_AUTO_CAPTURE_MAX_CHARS:-400}"
 GHOST_AUTO_SOURCE="${GHOST_AUTO_SOURCE:-claude-stop-hook}"
+GHOST_AUTO_CAPTURE_REQUIRE_SUMMARY="${GHOST_AUTO_CAPTURE_REQUIRE_SUMMARY:-1}"
 
 INPUT=$(cat || true)
 
@@ -22,26 +23,32 @@ if [ ! -f "$GHOST_MEMORY_SCRIPT" ]; then
 fi
 
 if [ "$GHOST_AUTO_CAPTURE_ON_STOP" = "1" ] && command -v jq >/dev/null 2>&1; then
+  if ! [[ "$GHOST_AUTO_CAPTURE_MAX_CHARS" =~ ^[0-9]+$ ]]; then
+    GHOST_AUTO_CAPTURE_MAX_CHARS=400
+  fi
+
   SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
   CURRENT_DIR=$(echo "$INPUT" | jq -r '.workspace.current_dir // empty' 2>/dev/null || true)
   MODEL=$(echo "$INPUT" | jq -r '.model.display_name // empty' 2>/dev/null || true)
-  SUMMARY=$(echo "$INPUT" | jq -r '.summary // .stop_hook_active_session.summary // empty' 2>/dev/null || true)
+  SUMMARY=$(echo "$INPUT" | jq -r '.summary // .stop_hook_active_session.summary // .stop_hook_active_session.stop_reason // empty' 2>/dev/null || true)
 
-  if [ -z "$SUMMARY" ]; then
-    SUMMARY="Claude session completed"
-  fi
+  if [ "$GHOST_AUTO_CAPTURE_REQUIRE_SUMMARY" = "1" ] && [ -z "$SUMMARY" ]; then
+    SUMMARY_TRIMMED=""
+  else
+    [ -z "$SUMMARY" ] && SUMMARY="Claude session completed"
 
-  if [ -n "$CURRENT_DIR" ]; then
-    SUMMARY="${SUMMARY} @${CURRENT_DIR}"
-  fi
-  if [ -n "$MODEL" ]; then
-    SUMMARY="${SUMMARY} [model:${MODEL}]"
-  fi
-  if [ -n "$SESSION_ID" ]; then
-    SUMMARY="${SUMMARY} [session:${SESSION_ID}]"
-  fi
+    if [ -n "$CURRENT_DIR" ]; then
+      SUMMARY="${SUMMARY} @${CURRENT_DIR}"
+    fi
+    if [ -n "$MODEL" ]; then
+      SUMMARY="${SUMMARY} [model:${MODEL}]"
+    fi
+    if [ -n "$SESSION_ID" ]; then
+      SUMMARY="${SUMMARY} [session:${SESSION_ID}]"
+    fi
 
-  SUMMARY_TRIMMED=$(echo "$SUMMARY" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | cut -c1-"$GHOST_AUTO_CAPTURE_MAX_CHARS")
+    SUMMARY_TRIMMED=$(echo "$SUMMARY" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' | cut -c1-"$GHOST_AUTO_CAPTURE_MAX_CHARS")
+  fi
 
   if [ -n "$SUMMARY_TRIMMED" ]; then
     python3 "$GHOST_MEMORY_SCRIPT" add \

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -6,7 +6,8 @@
     "GHOST_MEMORY_DB": "$HOME/.local/share/ghost/memory.db",
     "GHOST_AUTO_CAPTURE_ON_STOP": "1",
     "GHOST_AUTO_CAPTURE_MAX_CHARS": "400",
-    "GHOST_AUTO_SOURCE": "claude-stop-hook"
+    "GHOST_AUTO_SOURCE": "claude-stop-hook",
+    "GHOST_AUTO_CAPTURE_REQUIRE_SUMMARY": "1"
   },
   "permissions": {
     "allow": [

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -1,6 +1,9 @@
 {
   "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "1"
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "GHOST_HOME": "$HOME/.local/share/ghost",
+    "GHOST_MEMORY_SCRIPT": "$HOME/.local/share/ghost/memory.py",
+    "GHOST_MEMORY_DB": "$HOME/.local/share/ghost/memory.db"
   },
   "permissions": {
     "allow": [
@@ -66,6 +69,10 @@
     "Stop": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.config/claude/hooks/ghost-memory-sync.sh"
+          },
           {
             "type": "command",
             "command": "$HOME/.config/claude/hooks/notify.sh 'Claude Code - done' '完了または入力待ち' done"

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -3,7 +3,10 @@
     "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
     "GHOST_HOME": "$HOME/.local/share/ghost",
     "GHOST_MEMORY_SCRIPT": "$HOME/.local/share/ghost/memory.py",
-    "GHOST_MEMORY_DB": "$HOME/.local/share/ghost/memory.db"
+    "GHOST_MEMORY_DB": "$HOME/.local/share/ghost/memory.db",
+    "GHOST_AUTO_CAPTURE_ON_STOP": "1",
+    "GHOST_AUTO_CAPTURE_MAX_CHARS": "400",
+    "GHOST_AUTO_SOURCE": "claude-stop-hook"
   },
   "permissions": {
     "allow": [

--- a/.config/claude/skills/ghost-memory/SKILL.md
+++ b/.config/claude/skills/ghost-memory/SKILL.md
@@ -19,6 +19,7 @@ Use Ghost memory as a lightweight, local long-term memory for Claude sessions.
 Defaults:
 - `GHOST_MEMORY_SCRIPT=$HOME/.local/share/ghost/memory.py`
 - `GHOST_MEMORY_DB=$HOME/.local/share/ghost/memory.db`
+- `GHOST_AUTO_CAPTURE_ON_STOP=1` (automatic short memory on Claude Stop hook)
 
 ## Commands
 
@@ -51,3 +52,4 @@ python3 "$GHOST_MEMORY_SCRIPT" sync --db "$GHOST_MEMORY_DB"
 - Prefer concise, reusable memories (decision, trade-off, policy).
 - Avoid secrets (tokens, private keys, credentials).
 - If Ghost script is missing, skip gracefully and continue normal work.
+- To disable half-automatic memory capture, set `GHOST_AUTO_CAPTURE_ON_STOP=0`.

--- a/.config/claude/skills/ghost-memory/SKILL.md
+++ b/.config/claude/skills/ghost-memory/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: ghost-memory
+description: >
+  Persist and recall coding memories through Ghost's memory.py adapter.
+  Use this skill when users ask to save lessons learned, past decisions,
+  project conventions, or to search previously stored context.
+---
+
+# ghost-memory
+
+Use Ghost memory as a lightweight, local long-term memory for Claude sessions.
+
+## Preconditions
+
+- `python3` is installed.
+- `GHOST_MEMORY_SCRIPT` points to a working `memory.py`.
+- `GHOST_MEMORY_DB` points to a writable sqlite file.
+
+Defaults:
+- `GHOST_MEMORY_SCRIPT=$HOME/.local/share/ghost/memory.py`
+- `GHOST_MEMORY_DB=$HOME/.local/share/ghost/memory.db`
+
+## Commands
+
+### Save memory
+
+```bash
+python3 "$GHOST_MEMORY_SCRIPT" add \
+  --db "$GHOST_MEMORY_DB" \
+  --source "claude" \
+  --text "<記録したい内容>"
+```
+
+### Search memory
+
+```bash
+python3 "$GHOST_MEMORY_SCRIPT" search \
+  --db "$GHOST_MEMORY_DB" \
+  --query "<知りたい内容>" \
+  --top-k 5
+```
+
+### Sync embeddings / index
+
+```bash
+python3 "$GHOST_MEMORY_SCRIPT" sync --db "$GHOST_MEMORY_DB"
+```
+
+## Usage notes
+
+- Prefer concise, reusable memories (decision, trade-off, policy).
+- Avoid secrets (tokens, private keys, credentials).
+- If Ghost script is missing, skip gracefully and continue normal work.

--- a/.config/claude/skills/ghost-memory/SKILL.md
+++ b/.config/claude/skills/ghost-memory/SKILL.md
@@ -20,6 +20,7 @@ Defaults:
 - `GHOST_MEMORY_SCRIPT=$HOME/.local/share/ghost/memory.py`
 - `GHOST_MEMORY_DB=$HOME/.local/share/ghost/memory.db`
 - `GHOST_AUTO_CAPTURE_ON_STOP=1` (automatic short memory on Claude Stop hook)
+- `GHOST_AUTO_CAPTURE_REQUIRE_SUMMARY=1` (summaryが無いStopイベントでは保存しない)
 
 ## Commands
 
@@ -53,3 +54,4 @@ python3 "$GHOST_MEMORY_SCRIPT" sync --db "$GHOST_MEMORY_DB"
 - Avoid secrets (tokens, private keys, credentials).
 - If Ghost script is missing, skip gracefully and continue normal work.
 - To disable half-automatic memory capture, set `GHOST_AUTO_CAPTURE_ON_STOP=0`.
+- To allow fallback generic entries, set `GHOST_AUTO_CAPTURE_REQUIRE_SUMMARY=0`.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ Ghost memory integration docs:
 ```bash
 cat ~/.config/claude/ghost/README.md
 ```
+
+Stop hook automatically stores a short session memory and runs sync (best-effort).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Symlinks all files/dirs into `$HOME`, recursing into directories that already ex
 | Shell | zsh, sheldon, zeno, Starship |
 | Editor | Neovim, lspmux |
 | Git | lazygit |
+| AI coding | Claude Code (+ Ghost memory integration) |
 
 ## Notes
 
@@ -35,4 +36,12 @@ chmod +x ~/.local/bin/win32yank.exe
 ```bash
 curl -L https://github.com/cordx56/rustowl/releases/download/v1.0.0-rc.1/rustowl-x86_64-unknown-linux-gnu -o ~/.cargo/bin/rustowl
 chmod +x ~/.cargo/bin/rustowl
+```
+
+## Claude Code + Ghost
+
+Ghost memory integration docs:
+
+```bash
+cat ~/.config/claude/ghost/README.md
 ```


### PR DESCRIPTION
### Motivation

- Provide a lightweight local long-term memory integration for Claude Code using Ghost's `memory.py` adapter.
- Ensure embeddings/index sync runs on session Stop without blocking Claude by using a best-effort hook.
- Expose sensible defaults via environment variables so users can override paths for their Ghost checkout.

### Description

- Add `.config/claude/ghost/README.md` documenting setup, defaults, and safety notes for the Ghost memory integration.
- Add a non-blocking Stop hook script at `.config/claude/hooks/ghost-memory-sync.sh` that runs `python3 "$GHOST_MEMORY_SCRIPT" sync --db "$GHOST_MEMORY_DB"` if present and exits silently on error.
- Update `.config/claude/settings.json` to add `GHOST_HOME`, `GHOST_MEMORY_SCRIPT`, and `GHOST_MEMORY_DB` environment variables and register the new Stop hook command.
- Add a Claude skill at `.config/claude/skills/ghost-memory/SKILL.md` with example commands for `add`, `search`, and `sync` workflows.

### Testing

- No automated tests were executed for these configuration and documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54bf20ecc8324ab3e8d525c3a2fe4)